### PR TITLE
fixing exiting subroutine via next

### DIFF
--- a/tools/downtimes/sched_down.pl
+++ b/tools/downtimes/sched_down.pl
@@ -963,7 +963,7 @@ sub set_cmd {
 				$extcmd = "SCHEDULE_HOSTGROUP_SVC_DOWNTIME;$h;$data";
 				add_cmd (\@$cmd,$h,$key2,$extcmd);
 			} else { # one or more services defined
-				next if (already_planned (\@member,"HG",1,$key,$key2,$duration));
+				return 1 if (already_planned (\@member,"HG",1,$key,$key2,$duration));
 				for my $idx (0..$#member) {
 					if (exists $sObject{"$member[$idx]"}->{lc($s)}) {
 						$extcmd = "SCHEDULE_SVC_DOWNTIME;$member[$idx];$s;$data";


### PR DESCRIPTION
fixes: plugin did not call exit()\n**ePN /usr/local/bin/sched_down.pl: "Exiting subroutine via next at (eval 16) line 966